### PR TITLE
Fixed error when retrieving state from NetworkManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 .env/
 build/
+_trial_temp/
+*.~lock.*

--- a/magicicadaclient/networkstate/darwin.py
+++ b/magicicadaclient/networkstate/darwin.py
@@ -35,15 +35,17 @@ from ctypes import (
     c_void_p,
     c_uint32,
 )
+from ctypes.util import find_library
 from threading import Thread
 
 from twisted.internet import defer
 
 from magicicadaclient.networkstate import NetworkFailException
-from magicicadaclient.networkstate.networkstates import (ONLINE, OFFLINE, UNKNOWN)
-
-
-from ctypes.util import find_library
+from magicicadaclient.networkstate.networkstates import (
+    ONLINE,
+    OFFLINE,
+    UNKNOWN,
+)
 
 
 logger = logging.getLogger(__name__)

--- a/magicicadaclient/networkstate/linux.py
+++ b/magicicadaclient/networkstate/linux.py
@@ -76,7 +76,8 @@ class NetworkManagerState(object):
         """Called by DBus when the state is retrieved from NM."""
         # Assuming since Network Manager is not running,
         # the user has connected in some other way
-        logger.error("Error contacting NetworkManager: %s", error)
+        msg = error.message.encode('utf-8')
+        logger.error("Error contacting NetworkManager: %s", msg)
         self.call_result_cb(ONLINE)
 
     def state_changed(self, state):
@@ -100,9 +101,10 @@ class NetworkManagerState(object):
                         signal_name="StateChanged",
                         handler_function=self.state_changed,
                         dbus_interface=NM_DBUS_INTERFACE)
-            nm_proxy.Get(NM_DBUS_INTERFACE, "State",
-                         reply_handler=self.got_state,
-                         error_handler=self.got_error)
+            nm_proxy.state(
+                dbus_interface=NM_DBUS_INTERFACE,
+                reply_handler=self.got_state,
+                error_handler=self.got_error)
         except Exception as e:
             self.got_error(e)
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,3 +1,4 @@
 coverage==3.7.1
 flake8==3.5.0
+mock
 mocker==1.1.1


### PR DESCRIPTION
Error was:

2022-06-14 14:38:14,105 - magicicadaclient.networkstate.linux - ERROR - Error
contacting NetworkManager: org.freedesktop.DBus.Error.AccessDenied: Rejected
send message, 2 matched rules; type="method_call", sender=":1.38303" (uid=1000
pid=830699 comm=".env/bin/python bin/ubuntuone-syncdaemon --auth=te"
label="unconfined") interface="(unset)" member="state" error name="(unset)"
requested_reply="0" destination="org.freedesktop.NetworkManager" (uid=0 pid=1530
comm="/usr/sbin/NetworkManager --no-daemon " label="unconfined")

Also, get rid of mocker in this module, replacing it with mock in preparation
for the Python 3 port.