### PR TITLE
Minor fixes in preparation for Python 3 port

### DIFF
--- a/magicicadaclient/platform/tests/os_helper/test_windows.py
+++ b/magicicadaclient/platform/tests/os_helper/test_windows.py
@@ -317,7 +317,7 @@ class DecoratorsTestCase(TestCase):
         else:
             exc = self.assertRaises(
                 AssertionError, assert_windows_path, path, method_name)
-            self.assertTrue(method_name in exc.message)
+            self.assertIn(method_name, str(exc))
 
     def test_assert_windows_path_slash(self):
         """A path with a / is invalid."""

--- a/magicicadaclient/platform/tools/__init__.py
+++ b/magicicadaclient/platform/tools/__init__.py
@@ -205,7 +205,7 @@ class SyncDaemonTool(object):
                     d.callback(args)
             except Exception as e:
                 logger.exception('wait_for_signals: success_handler failed:')
-                d.errback(IPCError(e.__class__.__name__, args, e.message))
+                d.errback(IPCError(e.__class__.__name__, args, str(e)))
 
         def _error_handler(*args):
             """Errback 'd' only if the error_filter returns True."""
@@ -214,7 +214,7 @@ class SyncDaemonTool(object):
                     d.errback(IPCError(signal_error, args))
             except Exception as e:
                 logger.exception('wait_for_signals: error_handler failed:')
-                d.errback(IPCError(e.__class__.__name__, args, e.message))
+                d.errback(IPCError(e.__class__.__name__, args, str(e)))
 
         # register signal handlers for success/error
         match_ok = self.connect_signal(signal_name=signal_ok,

--- a/magicicadaclient/platform/tools/perspective_broker.py
+++ b/magicicadaclient/platform/tools/perspective_broker.py
@@ -170,11 +170,8 @@ class SyncDaemonToolProxy(object):
             result = yield self.call_method(
                 client_kind, method_name, *args, **kwargs)
         except RemoteError as e:
-            # Wrap RemoteErrors in IPCError to match DBus interface's
-            # behavior:
-            raise IPCError(name=e.remoteType,
-                           info=[e.args],
-                           details=e.message)
+            # Wrap RemoteErrors in IPCError to match DBus interface's behavior
+            raise IPCError(name=e.remoteType, info=[e.args], details=str(e))
         defer.returnValue(result)
 
     def shutdown(self):

--- a/magicicadaclient/syncdaemon/action_queue.py
+++ b/magicicadaclient/syncdaemon/action_queue.py
@@ -55,7 +55,7 @@ from magicicadaprotocol.context import get_ssl_context
 from twisted.internet import reactor, defer, task
 from twisted.internet import error as twisted_errors
 from twisted.python.failure import Failure, DefaultException
-from zope.interface import implements
+from zope.interface import implementer
 
 from magicicadaclient import clientdefs
 from magicicadaclient.platform import platform, remove_file
@@ -730,10 +730,10 @@ class UploadProgressWrapper(object):
         return getattr(self.fd, attr)
 
 
+@implementer(IActionQueue)
 class ActionQueue(ThrottlingStorageClientFactory, object):
     """The ActionQueue itself."""
 
-    implements(IActionQueue)
     protocol = ActionQueueProtocol
 
     def __init__(self, event_queue, main, connection_info,

--- a/magicicadaclient/syncdaemon/file_shelf.py
+++ b/magicicadaclient/syncdaemon/file_shelf.py
@@ -29,7 +29,7 @@
 
 from __future__ import with_statement
 
-import cPickle
+import cPickle as pickle
 import os
 import stat
 import errno
@@ -52,7 +52,7 @@ class FileShelf(object, DictMixin):
     """ File based shelf.
 
     It support arbritary python objects as values (anything accepted by
-    cPickle).  And support any valid file name as key.
+    pickle).  And support any valid file name as key.
     """
 
     def __init__(self, path, depth=3):
@@ -132,7 +132,7 @@ class FileShelf(object, DictMixin):
         This method allow subclasses to customize the unpickling.
 
         """
-        return cPickle.load(fd)
+        return pickle.load(fd)
 
     def _load_pickle(self, key, path):
         """Load a pickle form path that belongs to key.
@@ -144,7 +144,7 @@ class FileShelf(object, DictMixin):
         try:
             with open_file(path, "rb") as fd:
                 data = self._unpickle(fd)
-        except (EOFError, cPickle.UnpicklingError, ValueError):
+        except (EOFError, pickle.UnpicklingError, ValueError):
             # the metadata is broked, try to get .old version if it's available
             old_path = path + '.old'
             # only search for a single .old in the name
@@ -164,7 +164,7 @@ class FileShelf(object, DictMixin):
 
     def _pickle(self, value, fd, protocol):
         """Pickle value in fd using protocol."""
-        cPickle.dump(value, fd, protocol=protocol)
+        pickle.dump(value, fd, protocol=protocol)
 
     def __setitem__(self, key, value):
         """ setitem backed by the file storage """

--- a/magicicadaclient/syncdaemon/marker.py
+++ b/magicicadaclient/syncdaemon/marker.py
@@ -27,14 +27,14 @@
 # files in the program, then also delete it here.
 """Marker for mdids. """
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from magicicadaclient.syncdaemon.interfaces import IMarker
 
 
+@implementer(IMarker)
 class MDMarker(str):
     """A marker that has the mdid inside, for action queue."""
-    implements(IMarker)
 
     def __repr__(self):
         return "marker:%s" % self

--- a/magicicadaclient/syncdaemon/tests/test_fileshelf.py
+++ b/magicicadaclient/syncdaemon/tests/test_fileshelf.py
@@ -29,7 +29,7 @@
 
 from __future__ import with_statement
 
-import cPickle
+import cPickle as pickle
 import os
 import hashlib
 import unittest
@@ -255,17 +255,17 @@ class TestFileShelf(BaseTwistedTestCase):
 
             def _unpickle(self, fd):
                 """Custom _unpickle."""
-                return cPickle.loads(self.values[fd.name])
+                return pickle.loads(self.values[fd.name])
 
             def _pickle(self, value, fd, protocol=2):
                 """Custom _pickle."""
                 key = fd.name.strip('.new')
-                self.values[key] = cPickle.dumps(value, protocol=protocol)
+                self.values[key] = pickle.dumps(value, protocol=protocol)
 
         shelf = InMemoryFileShelf(self.path)
         shelf['foo'] = 'bar'
         self.assertIn('foo', shelf.values)
-        self.assertEqual(shelf.values['foo'], cPickle.dumps('bar', protocol=2))
+        self.assertEqual(shelf.values['foo'], pickle.dumps('bar', protocol=2))
 
     def test_broken_metadata_iteritems(self):
         """Test that broken metadata is ignored during iteritems."""

--- a/magicicadaclient/syncdaemon/tests/test_vm.py
+++ b/magicicadaclient/syncdaemon/tests/test_vm.py
@@ -32,7 +32,7 @@
 from __future__ import with_statement
 
 import collections
-import cPickle
+import cPickle as pickle
 import inspect
 import logging
 import os
@@ -1322,11 +1322,11 @@ class ModifySharesSubscriptionTests(ViewSharesSubscriptionTests):
         root = Root(node_id='root_node_id')
         del root.subscribed
         assert not hasattr(root, 'subscribed')
-        serialized = cPickle.dumps(root)
+        serialized = pickle.dumps(root)
         Root.subscribed = old_attr
 
         # unserialize
-        new_root = cPickle.loads(serialized)
+        new_root = pickle.loads(serialized)
         self.assertTrue(new_root.subscribed)
 
 
@@ -4206,7 +4206,7 @@ class VMTritcaskShelfTests(BaseTwistedTestCase):
         self.shelf[udf.volume_id] = udf
         self.assertEqual(udf, self.shelf[udf.volume_id])
         pickled_dict = self.shelf._db.get(1000, udf.volume_id)
-        udf_dict = cPickle.loads(pickled_dict)
+        udf_dict = pickle.loads(pickled_dict)
         self.assertEqual(udf.__dict__, udf_dict)
 
     def test_get_key(self):

--- a/magicicadaclient/syncdaemon/volume_manager.py
+++ b/magicicadaclient/syncdaemon/volume_manager.py
@@ -33,7 +33,7 @@ from __future__ import with_statement
 
 import itertools
 import functools
-import cPickle
+import cPickle as pickle
 import logging
 import os
 import re
@@ -1907,7 +1907,7 @@ class VMFileShelf(file_shelf.CachedFileShelf):
         value['type'].
 
         """
-        value = cPickle.load(fd)
+        value = pickle.load(fd)
         class_name = value[self.TYPE]
         clazz = self.classes[class_name]
         obj = clazz.__new__(clazz)
@@ -1916,7 +1916,7 @@ class VMFileShelf(file_shelf.CachedFileShelf):
 
     def _pickle(self, value, fd, protocol):
         """Pickle value in fd using protocol."""
-        cPickle.dump(value.__dict__, fd, protocol=protocol)
+        pickle.dump(value.__dict__, fd, protocol=protocol)
 
 
 class LegacyShareFileShelf(VMFileShelf):
@@ -1945,14 +1945,14 @@ class LegacyShareFileShelf(VMFileShelf):
 
     def _unpickle(self, fd):
         """Override _unpickle with one capable of migrating pickled classes."""
-        unpickler = cPickle.Unpickler(fd)
+        unpickler = pickle.Unpickler(fd)
         unpickler.find_global = self._find_global
         value = unpickler.load()
         return value
 
     def _pickle(self, value, fd, protocol):
         """Pickle value in fd using protocol."""
-        cPickle.dump(value, fd, protocol=protocol)
+        pickle.dump(value, fd, protocol=protocol)
 
 
 class VMTritcaskShelf(TritcaskShelf):
@@ -2009,7 +2009,7 @@ class VMTritcaskShelf(TritcaskShelf):
         Unpickle a dict and build the class instance specified in
         value['type'].
         """
-        value = cPickle.loads(pickled_value)
+        value = pickle.loads(pickled_value)
         class_name = value[self.TYPE]
         clazz = self.classes[class_name]
         obj = clazz.__new__(clazz)
@@ -2018,4 +2018,4 @@ class VMTritcaskShelf(TritcaskShelf):
 
     def _serialize(self, value):
         """Serialize value to string using protocol."""
-        return cPickle.dumps(value.__dict__, protocol=2)
+        return pickle.dumps(value.__dict__, protocol=2)

--- a/magicicadaclient/testing/testcase.py
+++ b/magicicadaclient/testing/testcase.py
@@ -43,7 +43,7 @@ from functools import wraps
 
 from twisted.internet import defer
 from twisted.trial.unittest import TestCase as TwistedTestCase
-from zope.interface import implements
+from zope.interface import implementer
 from zope.interface.verify import verifyObject
 
 from devtools.testcases import skipIfOS
@@ -141,10 +141,9 @@ class FakeExternalInterface(object):
         return FAKED_CREDENTIALS
 
 
+@implementer(interfaces.IActionQueue)
 class FakeActionQueue(object):
     """Stub implementation."""
-
-    implements(interfaces.IActionQueue)
 
     def __init__(self, eq, *args, **kwargs):
         """ Creates the instance """

--- a/magicicadaclient/utils/tests/test_txsecrets.py
+++ b/magicicadaclient/utils/tests/test_txsecrets.py
@@ -279,13 +279,13 @@ class SecretServiceMock(dbus.service.Object):
     def unlock_objects(self, objects):
         """Unlock the objects or its containers."""
         for c in self.collections.values():
-            for l in c.locations:
-                path = l[1]
+            for location in c.locations:
+                path = location[1]
                 if path in objects:
                     c.locked = False
             for i in c.items:
-                for l in i.locations:
-                    path = l[1]
+                for loc in i.locations:
+                    path = loc[1]
                     if path in objects:
                         c.locked = False
 
@@ -333,7 +333,7 @@ class SecretServiceMock(dbus.service.Object):
         """The only property implemented is Collections."""
         if interface == txsecrets.SERVICE_IFACE and \
                 propname == self.collections_property:
-            coll_paths = [make_coll_path(l) for l in self.collections]
+            coll_paths = [make_coll_path(loc) for loc in self.collections]
             return dbus.Array(coll_paths, signature="o", variant_level=1)
         raise InvalidProperty("Invalid property: {}".format(propname))
 


### PR DESCRIPTION
Use str(e) when getting exception messages instead of e.message
Upgrade the deprecated usage of zope.interface.implements