### PR TITLE
Fixed error when running the daemon with Stream handlers

### DIFF
--- a/magicicadaclient/syncdaemon/logger.py
+++ b/magicicadaclient/syncdaemon/logger.py
@@ -269,5 +269,5 @@ def rotate_logs(handlers):
     for handler in handlers:
         try:
             handler.doRollover()
-        except OSError:
+        except (AttributeError, OSError):
             pass


### PR DESCRIPTION
Failure instance: Traceback: <type 'exceptions.AttributeError'>: 'StreamHandler'
object has no attribute 'doRollover'