### PR TITLE
Misc fixes and cleanups taken from the Python 3 port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ build:
 
 bootstrap: deps venv build
 
-venv: 
+venv:
 	virtualenv -p python2 $(ENV)
 	$(ENV)/bin/pip install -U pip setuptools
 	$(ENV)/bin/pip install -r requirements.txt -r requirements-devel.txt

--- a/bin/u1sdtool
+++ b/bin/u1sdtool
@@ -32,7 +32,6 @@
 import codecs
 import os
 import sys
-import warnings
 from optparse import OptionParser
 
 if sys.platform not in ('win32', 'darwin'):  # noqa
@@ -212,7 +211,7 @@ def run(options, sync_daemon_tool, out):
     elif options.start:
         d = sync_daemon_tool.start()
     elif options.version:
-        print '%s - Version %s' % (os.path.basename(sys.argv[0]), VERSION)
+        print('%s - Version %s' % (os.path.basename(sys.argv[0]), VERSION))
         d = defer.succeed(None)
     else:
         parser.print_help()
@@ -221,8 +220,6 @@ def run(options, sync_daemon_tool, out):
 
 
 if __name__ == '__main__':
-    # disable the dbus warnings
-    warnings.filterwarnings('ignore', module='dbus')
     usage = "Usage: %prog [option]"
     parser = OptionParser(usage=usage)
     parser.add_option("-w", "--wait", dest="wait", action="store_true",

--- a/bin/ubuntuone-syncdaemon
+++ b/bin/ubuntuone-syncdaemon
@@ -84,8 +84,9 @@ def main(argv):
         configs.append(args.pop(0))
     if len(configs) == 0:
         configs.extend(config.get_config_files())
-    (parser, options, argv) = config.configglue(file(configs[0]), *configs[1:],
-                                                args=args, usage=usage)
+    with open(configs[0]) as f:
+        (parser, options, argv) = config.configglue(
+            f, *configs[1:], args=args, usage=usage)
     d = async_main(parser, options, argv)
     d.addErrback(check_death)
     d.addErrback(logger.root_logger.exception)

--- a/contrib/devtools/runners/__init__.py
+++ b/contrib/devtools/runners/__init__.py
@@ -225,9 +225,7 @@ class BaseTestOptions(OptionParser):
             raise UsageError('A positive integer value must be specified.')
 
     def opt_temp_directory(self, option):
-        """Path to use as a working directory for tests.
-           [default: _trial_temp]
-           """
+        """Path for the working directory for tests (default _trial_temp)."""
         self['temp-directory'] = option
 
     def opt_test(self, option):
@@ -241,6 +239,8 @@ class BaseTestOptions(OptionParser):
             self['tests'].update(args)
         elif isinstance(self.tests, list):
             self['tests'].extend(args)
+        else:
+            raise ValueError(args)
 
 
 def _get_runner_options(runner_name):

--- a/contrib/devtools/runners/txrunner.py
+++ b/contrib/devtools/runners/txrunner.py
@@ -32,6 +32,8 @@ from __future__ import unicode_literals
 
 import sys
 
+from twisted.internet import defer
+from twisted.python import failure
 from twisted.scripts import trial
 from twisted.trial.runner import TrialRunner
 
@@ -39,6 +41,12 @@ from devtools.errors import TestError
 from devtools.runners import BaseTestOptions, BaseTestRunner
 
 __all__ = ['TestRunner', 'TestOptions']
+
+
+def _initialDebugSetup():
+    # Taken from Twisted's src/twisted/scripts/trial.py
+    failure.startDebugMode()
+    defer.setDebugging(True)
 
 
 class TestRunner(BaseTestRunner, TrialRunner):
@@ -63,8 +71,12 @@ class TestRunner(BaseTestRunner, TrialRunner):
                     reactor.REACTOR_URL)
 
         mode = None
+        debugger = None
         if self.config['debug']:
+            _initialDebugSetup()
             mode = TrialRunner.DEBUG
+            import pdb
+            debugger = pdb
         if self.config['dry-run']:
             mode = TrialRunner.DRY_RUN
 
@@ -73,6 +85,7 @@ class TestRunner(BaseTestRunner, TrialRunner):
             options=options,
             reporterFactory=self.config['reporter'],
             mode=mode,
+            debugger=debugger,
             profile=self.config['profile'],
             logfile=self.config['logfile'],
             tracebackFormat=self.config['tbformat'],

--- a/contrib/devtools/services/dbus.py
+++ b/contrib/devtools/services/dbus.py
@@ -95,12 +95,12 @@ class DBusRunner(object):
         # Call wait here as under the qt4 reactor we get an error about
         # interrupted system call if we don't.
         sp.wait()
-        self.dbus_address = b"".join(sp.stdout.readlines()).strip()
+        self.dbus_address = (
+            b"".join(sp.stdout.readlines()).strip().decode("utf8"))
         self.dbus_pid = int(b"".join(sp.stderr.readlines()).strip())
 
         if self.dbus_address != "":
-            os.environ["DBUS_SESSION_BUS_ADDRESS"] = \
-                self.dbus_address.decode("utf8")
+            os.environ["DBUS_SESSION_BUS_ADDRESS"] = self.dbus_address
         else:
             os.kill(self.dbus_pid, signal.SIGKILL)
             raise DBusLaunchError("There was a problem launching dbus-daemon.")

--- a/contrib/devtools/utils.py
+++ b/contrib/devtools/utils.py
@@ -34,6 +34,7 @@ import getopt
 import sys
 
 from devtools.errors import UsageError
+
 __all__ = ['OptionParser']
 
 
@@ -100,7 +101,7 @@ class OptionParser(dict):
             else:
                 opt = opt[1:]
 
-            if (opt not in self.synonyms.keys()):
+            if (opt not in list(self.synonyms.keys())):
                 raise UsageError('No such options: "%s"' % opt)
 
             opt = self.synonyms[opt]

--- a/contrib/dirspec/basedir.py
+++ b/contrib/dirspec/basedir.py
@@ -19,10 +19,16 @@ from __future__ import unicode_literals
 
 import os
 
-from dirspec.utils import (default_cache_home,
-                           default_config_path, default_config_home,
-                           default_data_path, default_data_home,
-                           get_env_path, unicode_path)
+from dirspec.utils import (
+    default_cache_home,
+    default_config_home,
+    default_config_path,
+    default_data_home,
+    default_data_path,
+    get_env_path,
+    unicode_path,
+)
+
 
 __all__ = ['xdg_cache_home',
            'xdg_config_home',
@@ -70,6 +76,23 @@ def get_xdg_data_dirs():
     return result
 
 
+def load_paths(search_dirs, *resource):
+    """Iterator of various paths.
+
+    Return an iterator which gives each directory named 'resource' in the
+    search dirs. Information provided by earlier directories should take
+    precedence over later ones (ie, the user's config dir comes first).
+    """
+    resource = os.path.join(*resource)
+    assert not resource.startswith('/')
+    for target in search_dirs:
+        path = os.path.join(target, resource.encode('utf-8'))
+        # access the file system always with unicode
+        # to properly behave in some operating systems
+        if os.path.exists(unicode_path(path)):
+            yield path
+
+
 def load_config_paths(*resource):
     """Iterator of configuration paths.
 
@@ -78,14 +101,7 @@ def load_config_paths(*resource):
     directories should take precedence over later ones (ie, the user's
     config dir comes first).
     """
-    resource = os.path.join(*resource)
-    assert not resource.startswith('/')
-    for config_dir in get_xdg_config_dirs():
-        path = os.path.join(config_dir, resource.encode('utf-8'))
-        # access the file system always with unicode
-        # to properly behave in some operating systems
-        if os.path.exists(unicode_path(path)):
-            yield path
+    return load_paths(get_xdg_config_dirs(), *resource)
 
 
 def load_data_paths(*resource):
@@ -95,14 +111,7 @@ def load_data_paths(*resource):
     the stored data search path. Information provided by earlier
     directories should take precedence over later ones.
     """
-    resource = os.path.join(*resource)
-    assert not resource.startswith('/')
-    for data_dir in get_xdg_data_dirs():
-        path = os.path.join(data_dir, resource.encode('utf-8'))
-        # access the file system always with unicode
-        # to properly behave in some operating systems
-        if os.path.exists(unicode_path(path)):
-            yield path
+    return load_paths(get_xdg_data_dirs(), *resource)
 
 
 def load_first_config(*resource):

--- a/contrib/dirspec/utils.py
+++ b/contrib/dirspec/utils.py
@@ -110,11 +110,13 @@ def get_env_path(key, default):
             path = os.environb.get(key.encode('utf-8'))
         except AttributeError:
             path = os.environ[key]
-        return path.decode(sys.getfilesystemencoding()).encode('utf-8')
+        result = path.decode(sys.getfilesystemencoding()).encode('utf-8')
+    elif not isinstance(default, bytes):
+        result = default.encode('utf-8')
     else:
-        if not isinstance(default, bytes):
-            return default.encode('utf-8')
-        return default
+        result = default
+
+    return result
 
 
 def unicode_path(utf8path):

--- a/magicicadaclient/logger.py
+++ b/magicicadaclient/logger.py
@@ -246,7 +246,7 @@ class DebugCapture(logging.Handler):
             self.emit_debug()
         self.uninstall()
         if self.raise_unhandled and exc_type is not None:
-            raise exc_type, exc_value, traceback
+            raise exc_type(exc_value).with_traceback(traceback)
         else:
             return True
 

--- a/magicicadaclient/networkstate/tests/test_darwin.py
+++ b/magicicadaclient/networkstate/tests/test_darwin.py
@@ -131,7 +131,7 @@ class TestReadingFlags(TestCase):
         code on, or that the server we're testing for is on this
         machine or wired directly to it. These cases won't happen.
         """
-        for flag in range(0, 17) + [1 << 16, 1 << 17, 1 << 18]:
+        for flag in list(range(0, 17)) + [1 << 16, 1 << 17, 1 << 18]:
             # only test cases without the reachable bit set:
             flag = flag & ~ 2
             self.assertFalse(flags_say_reachable(flag))

--- a/magicicadaclient/platform/__init__.py
+++ b/magicicadaclient/platform/__init__.py
@@ -60,7 +60,6 @@ def expand_user(path):
             (len(path) > 1 and path[1:2] != os.path.sep)):
         return path
     result = path.replace('~', user_home, 1)
-
     assert isinstance(result, str)
     try:
         result.decode('utf-8')

--- a/magicicadaclient/platform/filesystem_notifications/monitor/__init__.py
+++ b/magicicadaclient/platform/filesystem_notifications/monitor/__init__.py
@@ -54,8 +54,8 @@ if sys.platform == 'win32':
 
 elif sys.platform == 'darwin':
     from magicicadaclient.platform.filesystem_notifications.monitor import (
-        darwin,
         common,
+        darwin,
     )
 
     FILEMONITOR_IDS = {

--- a/magicicadaclient/platform/filesystem_notifications/monitor/common.py
+++ b/magicicadaclient/platform/filesystem_notifications/monitor/common.py
@@ -34,6 +34,7 @@ import sys
 
 from twisted.internet import defer
 
+from magicicadaclient import logger
 from magicicadaclient.platform.filesystem_notifications import notify_processor
 from magicicadaclient.platform.filesystem_notifications.agnostic import (
     Event,
@@ -44,9 +45,6 @@ from magicicadaclient.platform.filesystem_notifications.agnostic import (
     IN_MOVED_FROM,
     IN_MOVED_TO,
 )
-
-from magicicadaclient import logger
-
 from magicicadaclient.platform.os_helper import (
     is_valid_syncdaemon_path,
     is_valid_os_path,

--- a/magicicadaclient/platform/filesystem_notifications/notify_processor/common.py
+++ b/magicicadaclient/platform/filesystem_notifications/notify_processor/common.py
@@ -47,10 +47,7 @@ from magicicadaclient.platform.filesystem_notifications.agnostic import (
     IN_MOVED_FROM,
     IN_MOVED_TO,
 )
-
-from magicicadaclient.platform.os_helper import (
-    is_valid_syncdaemon_path,
-)
+from magicicadaclient.platform.os_helper import is_valid_syncdaemon_path
 
 if sys.platform == 'win32':
 

--- a/magicicadaclient/platform/ipc/linux.py
+++ b/magicicadaclient/platform/ipc/linux.py
@@ -92,15 +92,14 @@ class DBusExposedObject(dbus.service.Object):
         """Add <docstring> tag to reflection_data if func.__doc__ isnt None."""
         # add docstring element
         if getattr(func, '__doc__', None) is not None:
-
             element = ElementTree.fromstring(reflection_data)
             doc = element.makeelement('docstring', dict())
             data = '<![CDATA[' + func.__doc__ + ']]>'
             doc.text = '%s'
             element.insert(0, doc)
-            return ElementTree.tostring(element) % data
-        else:
-            return reflection_data
+            reflection_data = ElementTree.tostring(element) % data
+
+        return reflection_data
 
     @classmethod
     def _reflect_on_method(cls, func):
@@ -196,7 +195,7 @@ class Status(DBusExposedObject):
     def UploadFinished(self, path, info):
         """Fire a signal to notify that an upload has finished."""
 
-    @dbus.service.signal(DBUS_IFACE_STATUS_NAME, signature='say')
+    @dbus.service.signal(DBUS_IFACE_STATUS_NAME, signature='ss')
     def InvalidName(self, dirname, filename):
         """Fire a signal to notify an invalid file or dir name."""
 
@@ -246,8 +245,7 @@ class Events(DBusExposedObject):
 
     path = '/events'
 
-    @dbus.service.signal(DBUS_IFACE_EVENTS_NAME,
-                         signature='a{ss}')
+    @dbus.service.signal(DBUS_IFACE_EVENTS_NAME, signature='a{ss}')
     def Event(self, event_dict):
         """Fire a signal, notifying an event."""
 

--- a/magicicadaclient/platform/os_helper/windows.py
+++ b/magicicadaclient/platform/os_helper/windows.py
@@ -126,6 +126,7 @@ def _int_to_bin(n):
 
 
 # Functions to be used for path validation
+# XXX consider switching validation to the `pathvalidate` library
 
 def _add_method_info(messages, method_name=None):
     """Loop through the messages and add the extra info."""
@@ -150,6 +151,7 @@ def assert_windows_path(path, method_name=None):
 
     Opcionally the name of the method that called the assertion can be passed
     to improve the assertion message.
+
     """
     messages = {
         'unicode_path': 'Path %r should be unicode.',
@@ -210,8 +212,7 @@ def _bytes_to_unicode(path):
     # remove the illegal windows chars with similar ones
     for invalid, valid in WINDOWS_ILLEGAL_CHARS_MAP.items():
         path = path.replace(invalid, valid)
-    path = drive + path
-    return path
+    return drive + path
 
 
 def get_windows_valid_path(path):

--- a/magicicadaclient/platform/tests/filesystem_notifications/__init__.py
+++ b/magicicadaclient/platform/tests/filesystem_notifications/__init__.py
@@ -41,7 +41,7 @@ from magicicadaclient.testing import testcase
 class BaseFSMonitorTestCase(testcase.BaseTwistedTestCase):
     """Test the structures where we have the path/watch."""
 
-    timeout = 3
+    timeout = 2
 
     @defer.inlineCallbacks
     def setUp(self):

--- a/magicicadaclient/platform/tests/filesystem_notifications/common.py
+++ b/magicicadaclient/platform/tests/filesystem_notifications/common.py
@@ -125,7 +125,7 @@ class TestCaseHandler(ProcessEvent):
 class TestWatch(BaseTwistedTestCase):
     """Test the watch so that it returns the same events as pyinotify."""
 
-    timeout = 5
+    timeout = 2
 
     @defer.inlineCallbacks
     def setUp(self):
@@ -1248,7 +1248,7 @@ class TestNotifyProcessor(BaseTwistedTestCase):
 class FilesystemMonitorTestCase(BaseTwistedTestCase):
     """Tests for the FilesystemMonitor."""
 
-    timeout = 5
+    timeout = 2
 
     def test_add_watch_twice(self):
         """Check the deferred returned by a second add_watch."""

--- a/magicicadaclient/platform/tests/filesystem_notifications/test_agnostic.py
+++ b/magicicadaclient/platform/tests/filesystem_notifications/test_agnostic.py
@@ -36,7 +36,8 @@ from twisted.internet import defer
 from twisted.trial.unittest import TestCase
 
 from magicicadaclient.platform.filesystem_notifications.agnostic import (
-    RawOutputFormat)
+    RawOutputFormat,
+)
 
 
 class RawOutputFormatTest(TestCase):
@@ -48,8 +49,8 @@ class RawOutputFormatTest(TestCase):
         self.format = {'normal': 'normal'}
         self.formatter = RawOutputFormat(self.format)
 
-    def test_simple_unicode(self):
-        """Test the formatting of a simple value that is unicode."""
+    def test_simple_non_ascii(self):
+        """Test the formatting of a simple value that is non-ascii str."""
         attr = 'attribute'
         self.format[attr] = attr
         value = u'ñoño'

--- a/magicicadaclient/platform/tests/filesystem_notifications/test_darwin.py
+++ b/magicicadaclient/platform/tests/filesystem_notifications/test_darwin.py
@@ -159,7 +159,7 @@ class TestCaseHandler(ProcessEvent):
 class TestWatch(common_tests.TestWatch):
     """Test the watch so that it returns the same events as pyinotify."""
 
-    timeout = 5
+    timeout = 2
 
     @defer.inlineCallbacks
     def setUp(self):
@@ -754,7 +754,8 @@ class TestWatchManager(common_tests.TestWatchManager):
 
 class TestWatchManagerAddWatches(BaseTwistedTestCase):
     """Test the watch manager."""
-    timeout = 5
+
+    timeout = 2
 
     def test_add_watch_twice(self):
         """Adding a watch twice succeeds when the watch is running."""

--- a/magicicadaclient/platform/tests/filesystem_notifications/test_windows.py
+++ b/magicicadaclient/platform/tests/filesystem_notifications/test_windows.py
@@ -65,7 +65,7 @@ class FakeEventsProcessor(object):
 class TestWatch(common_tests.TestWatch):
     """Test the watch so that it returns the same events as pyinotify."""
 
-    timeout = 5
+    timeout = 2
 
     @defer.inlineCallbacks
     def setUp(self):
@@ -268,7 +268,8 @@ class TestWatchManager(common_tests.TestWatchManager):
 
 class TestWatchManagerAddWatches(BaseTwistedTestCase):
     """Test the watch manager."""
-    timeout = 5
+
+    timeout = 2
 
     def test_add_watch_twice(self):
         """Adding a watch twice succeeds when the watch is running."""
@@ -284,7 +285,7 @@ class TestWatchManagerAddWatches(BaseTwistedTestCase):
         self.assertFalse(d1.called, "Should not be called yet.")
         self.assertFalse(d2.called, "Should not be called yet.")
 
-        manager._wdm.values()[0].started.callback(True)
+        list(manager._wdm.values())[0].started.callback(True)
 
         self.assertTrue(d1.called, "Should already be called.")
         self.assertTrue(d2.called, "Should already be called.")
@@ -301,7 +302,8 @@ class TestNotifyProcessor(common_tests.TestNotifyProcessor):
 
 class FilesystemMonitorTestCase(common_tests.FilesystemMonitorTestCase):
     """Tests for the FilesystemMonitor."""
-    timeout = 5
+
+    timeout = 2
 
     def test_add_watch_twice(self):
         """Check the deferred returned by a second add_watch."""
@@ -317,7 +319,7 @@ class FilesystemMonitorTestCase(common_tests.FilesystemMonitorTestCase):
         self.assertFalse(d1.called, "Should not be called yet.")
         self.assertFalse(d2.called, "Should not be called yet.")
 
-        monitor._watch_manager._wdm.values()[0].started.callback(True)
+        list(monitor._watch_manager._wdm.values())[0].started.callback(True)
 
         self.assertTrue(d1.called, "Should already be called.")
         self.assertTrue(d2.called, "Should already be called.")

--- a/magicicadaclient/platform/tests/ipc/test_linux.py
+++ b/magicicadaclient/platform/tests/ipc/test_linux.py
@@ -57,13 +57,13 @@ from magicicadaclient.platform.tools.linux import DBusClient
 
 
 class FakeNetworkManager(DBusExposedObject):
-    """ A fake NetworkManager that only emits StatusChanged signal. """
+    """A fake NetworkManager that only emits StatusChanged signal."""
 
     State = 3
     path = '/org/freedesktop/NetworkManager'
 
     def __init__(self, bus):
-        """ Creates the instance. """
+        """Create the instance."""
         self.bus = bus
         self.bus.request_name('org.freedesktop.NetworkManager',
                               flags=dbus.bus.NAME_FLAG_REPLACE_EXISTING |
@@ -75,20 +75,20 @@ class FakeNetworkManager(DBusExposedObject):
                                    service=None)
 
     def shutdown(self):
-        """ Shutdown the fake NetworkManager """
+        """Shutdown the fake NetworkManager."""
         self.busName.get_bus().release_name(self.busName.get_name())
         self.remove_from_connection()
 
     @dbus.service.signal('org.freedesktop.NetworkManager', signature='i')
     def StateChanged(self, state):
-        """ Fire DBus signal StatusChanged. """
+        """Fire DBus signal StatusChanged."""
 
     def emit_connected(self):
-        """ Emits the signal StateCganged(3). """
+        """Emits the signal StateChanged(3)."""
         self.StateChanged(70)
 
     def emit_disconnected(self):
-        """ Emits the signal StateCganged(4). """
+        """Emits the signal StateChanged(4)."""
         self.StateChanged(20)
 
     @dbus.service.method(dbus.PROPERTIES_IFACE,
@@ -108,9 +108,9 @@ class FakeNetworkManager(DBusExposedObject):
 
 
 class IPCTestCase(FakeMainTestCase, DBusTestCase):
-    """Test the IPC handling"""
+    """Test the IPC handling."""
 
-    timeout = 5
+    timeout = 2
     service_class = FakedService
     path = None
     iface = None
@@ -200,7 +200,10 @@ class IPCTestCase(FakeMainTestCase, DBusTestCase):
 
         self.assertTrue(signal._dbus_is_signal)
         self.assertEqual(signal._dbus_interface, self.iface)
-        signal(*args)
+        try:
+            signal(*args)
+        except TypeError as e:
+            self.fail(str(e) + ' Signal name %s(%s)' % (signal_name, args))
 
     def test_remote_signals(self):
         """Check every signal defined in self.signal_mapping.

--- a/magicicadaclient/platform/tests/ipc/test_perspective_broker.py
+++ b/magicicadaclient/platform/tests/ipc/test_perspective_broker.py
@@ -96,10 +96,6 @@ class FakeActivationClient(object):
 class FakeDecoratedObject(object):
     """An object that has decorators."""
 
-    def __init__(self):
-        """Create a new instance."""
-        super(FakeDecoratedObject, self).__init__()
-
     @signal
     def on_no_args(self):
         """Get no args passwed."""
@@ -379,7 +375,7 @@ class RemoteClientTestCase(TestCase):
 class IPCTestCase(FakeMainTestCase, TCPPbServerTestCase):
     """Set the ipc to a random port for this instance."""
 
-    timeout = 5
+    timeout = 2
     service_class = FakedService
     client_name = None
     client_class = None

--- a/magicicadaclient/platform/tests/linux/test_vm.py
+++ b/magicicadaclient/platform/tests/linux/test_vm.py
@@ -911,13 +911,13 @@ class MetadataNewLayoutTests(MetadataTestCase):
                     old_upgrade_share_to_volume
 
         shares = LegacyShareFileShelf(self.share_md_dir)
-        self.assertEqual(len(list(shares.keys())), len(legacy_shares.keys()))
+        self.assertItemsEqual(shares.keys(), legacy_shares.keys())
         for sid, share in shares.items():
             old_share = legacy_shares[sid]
             self.assertIsInstance(share, _Share)
             self.assertIsInstance(old_share, _Share)
         shared = LegacyShareFileShelf(self.shared_md_dir)
-        self.assertEqual(len(list(shared.keys())), len(legacy_shared.keys()))
+        self.assertItemsEqual(shares.keys(), legacy_shares.keys())
         for sid, share in shared.items():
             old_share = legacy_shared[sid]
             self.assertIsInstance(share, _Share)

--- a/magicicadaclient/platform/tests/session/test_linux.py
+++ b/magicicadaclient/platform/tests/session/test_linux.py
@@ -76,7 +76,7 @@ class FakeGnomeSessionManagerInhibitor(dbus.service.Object):
 class SessionDBusClientTestCase(DBusTestCase):
     """Test the DBus session manager client"""
 
-    timeout = 5
+    timeout = 2
 
     @inlineCallbacks
     def setUp(self):

--- a/magicicadaclient/platform/tests/test_tools.py
+++ b/magicicadaclient/platform/tests/test_tools.py
@@ -56,7 +56,7 @@ class TestToolsBase(IPCTestCase):
     """Base test case for SyncDaemonTool tests."""
 
     service_class = interaction_interfaces.SyncdaemonService
-    timeout = 5
+    timeout = 2
 
     @defer.inlineCallbacks
     def setUp(self):
@@ -73,9 +73,9 @@ class TestToolsBase(IPCTestCase):
                    lambda: self.called.append('start') or defer.succeed(None))
         self.patch(self.main, 'quit',
                    lambda: self.called.append('quit') or defer.succeed(None))
-
         self.patch(tools, 'is_already_running',
                    lambda bus: defer.succeed(True))
+
         yield self.main.wait_for_nirvana(last_event_interval=0.001)
 
     def _create_share(self, accepted=True, subscribed=True):
@@ -124,13 +124,13 @@ class TestToolsBasic(TestToolsBase):
 
     @defer.inlineCallbacks
     def test_all_downloads(self):
-        """ test wait_all_downloads """
+        """Test wait_all_downloads."""
         result = yield self.tool.wait_all_downloads()
         self.assertTrue(result)
 
     @defer.inlineCallbacks
     def test_all_uploads(self):
-        """ test wait_all_uploads """
+        """Test wait_all_uploads."""
         result = yield self.tool.wait_all_uploads()
         self.assertTrue(result)
 
@@ -696,7 +696,7 @@ class TestToolsSomeMore(TestToolsBase):
         self.assertEqual('http://example.com', file_info['public_url'])
 
     @defer.inlineCallbacks
-    def test_change_public_access_with_unicode(self):
+    def test_change_public_access_with_non_ascii(self):
         """Test change_public_access."""
         # XXX: change public access is the only class that expects uuid's as
         # params this may indicate that we need to refactor that class to be

--- a/magicicadaclient/platform/tests/test_u1sdtool.py
+++ b/magicicadaclient/platform/tests/test_u1sdtool.py
@@ -33,7 +33,7 @@
 import os
 
 from operator import itemgetter
-from StringIO import StringIO
+from io import StringIO
 
 from twisted.internet import defer
 
@@ -135,8 +135,8 @@ class U1SDToolTests(TestToolsBase):
         d.addCallback(check)
         return d
 
-    def test_show_path_info_unicode(self):
-        """test the output of --info with unicode paths """
+    def test_show_path_info_non_ascii(self):
+        """Test the output of --info with non-ascii paths """
         return self.generic_test_show_path_info_unicode('utf-8')
 
     def test_show_path_info_unicode_pipe(self):
@@ -421,7 +421,9 @@ class U1SDToolTests(TestToolsBase):
             # dirty some
             self.main.fs.set_by_mdid(mdid2, dirty=True)
             self.main.fs.set_by_mdid(mdid4, dirty=True)
+
         dirty_nodes = yield self.tool.get_dirty_nodes()
+
         out = StringIO()
         out.encoding = encoding
         # sort the list
@@ -446,8 +448,8 @@ class U1SDToolTests(TestToolsBase):
             value = " No dirty nodes.\n"
         self.assertEqual(out.getvalue(), value)
 
-    def test_show_dirty_nodes(self):
-        """Test show_dirty_nodes with unicode paths."""
+    def test_show_dirty_nodes_non_ascii(self):
+        """Test show_dirty_nodes with non-ascii paths."""
         return self.generic_show_dirty_nodes("utf-8")
 
     def test_show_dirty_nodes_pipe(self):

--- a/magicicadaclient/platform/tests/windows/run_sdtool.py
+++ b/magicicadaclient/platform/tests/windows/run_sdtool.py
@@ -39,25 +39,25 @@ def print_test():
     sdtool = tools.SyncDaemonTool()
     yield sdtool.client.connect()
     result = yield sdtool.get_current_downloads()
-    print 'Current downloads are: '
+    print('Current downloads are: ')
     for download in result:
-        print download
+        print(download)
     result = yield sdtool.get_current_uploads()
-    print 'Current Uplaods are: '
+    print('Current Uplaods are: ')
     for upload in result:
-        print upload
-    print 'The current config is:'
+        print(upload)
+    print('The current config is:')
     shares_link = yield sdtool.get_shares_dir_link()
-    print '\tShares link: %s' % shares_link
+    print('\tShares link: %s' % shares_link)
     shares_dir = yield sdtool.get_shares_dir()
-    print '\tShares dir: %s' % shares_dir
+    print('\tShares dir: %s' % shares_dir)
     root_dir = yield sdtool.get_root_dir()
-    print '\tRoot dir: %s' % root_dir
+    print('\tRoot dir: %s' % root_dir)
     is_udf_autosubscribe_enabled = yield sdtool.is_udf_autosubscribe_enabled()
-    print '\tAutosubscribe enabled: %s' % is_udf_autosubscribe_enabled
+    print('\tAutosubscribe enabled: %s' % is_udf_autosubscribe_enabled)
     is_share_autosubscribe_enabled = (
         yield sdtool.is_share_autosubscribe_enabled())
-    print '\tAutosubscribe enabled: %s' % is_share_autosubscribe_enabled
+    print('\tAutosubscribe enabled: %s' % is_share_autosubscribe_enabled)
     reactor.stop()
 
 

--- a/magicicadaclient/platform/tools/linux.py
+++ b/magicicadaclient/platform/tools/linux.py
@@ -117,7 +117,8 @@ class DBusClient(object):
             else:
                 reply_handler(tuple(args_list))
 
-        self.bus.send_message_with_reply(msg, reply_handler=parse_reply)
+        self.bus.send_message_with_reply(
+            msg, reply_handler=parse_reply, require_main_loop=True)
 
         return d
 

--- a/magicicadaclient/platform/tools/perspective_broker.py
+++ b/magicicadaclient/platform/tools/perspective_broker.py
@@ -172,6 +172,7 @@ class SyncDaemonToolProxy(object):
         except RemoteError as e:
             # Wrap RemoteErrors in IPCError to match DBus interface's behavior
             raise IPCError(name=e.remoteType, info=[e.args], details=str(e))
+
         defer.returnValue(result)
 
     def shutdown(self):

--- a/magicicadaclient/syncdaemon/config.py
+++ b/magicicadaclient/syncdaemon/config.py
@@ -52,28 +52,17 @@ from magicicadaclient.platform import (
 
 # the try/except is to work with older versions of configglue (that
 # had everything that is now configglue.inischema.* as configglue.*).
-# The naming shenanigans are to work around pyflakes being completely
-# stupid WRT people catching ImportErrors
-normoptname = None
 try:
-    from configglue.glue import normoptname as old_normoptname
-    from configglue import TypedConfigParser as old_tcp
+    from configglue.glue import normoptname
+    from configglue import TypedConfigParser
 except ImportError:
-    from configglue.inischema import TypedConfigParser as new_tcp
+    from configglue.inischema import TypedConfigParser
 
     def normoptname(_, section, option):
         if section == "__main__":
             return option
         return section + "_" + option
 
-if normoptname is None:
-    normoptname = old_normoptname
-    TypedConfigParser = old_tcp
-    del old_normoptname, old_tcp
-else:
-    TypedConfigParser = new_tcp
-    del new_tcp
-# end of naming shenanigans
 
 BASE_FILE_PATH = 'magicicada'
 CONFIG_FILE = 'syncdaemon.conf'

--- a/magicicadaclient/syncdaemon/event_queue.py
+++ b/magicicadaclient/syncdaemon/event_queue.py
@@ -228,8 +228,9 @@ class EventQueue(object):
         """Make the monitor shutdown."""
         yield self.monitor.shutdown()
         # clean up all registered listeners
-        if len(self.listener_map.items()) > 0:
-            for k, v in self.listener_map.items():
+        listeners = list(self.listener_map.items())
+        if len(listeners) > 0:
+            for k, v in listeners:
                 v.clear()
                 del self.listener_map[k]
 
@@ -258,7 +259,7 @@ class EventQueue(object):
 
         @param obj: the callback object to remove from the queue.
         """
-        for k, v in self.listener_map.items():
+        for k, v in list(self.listener_map.items()):
             v.pop(obj, None)
             if not v:
                 del self.listener_map[k]
@@ -316,7 +317,7 @@ class EventQueue(object):
             return
 
         # check listeners to see if have the proper method, and call it
-        for listener, method in listeners.items():
+        for listener, method in list(listeners.items()):
             try:
                 method(**kwargs)
             except self.ignored_base_exception:

--- a/magicicadaclient/syncdaemon/events_nanny.py
+++ b/magicicadaclient/syncdaemon/events_nanny.py
@@ -67,8 +67,8 @@ class DownloadFinishedNanny(object):
         path_from += "/"
 
         def fix(d):
-            """Fixes the dict."""
-            for path in d:
+            """Fixes the dict in-place, needs a copy."""
+            for path in d.copy():
                 if path.startswith(path_from):
                     info = d.pop(path)
                     d[path_to + path[len(path_from) - 1:]] = info

--- a/magicicadaclient/syncdaemon/fsm/fsm.py
+++ b/magicicadaclient/syncdaemon/fsm/fsm.py
@@ -51,11 +51,9 @@ class ValidationError(object):
     """Contains validation errors"""
 
     def __init__(self, description):
-        "create a validation error with description"
         self.description = description
 
     def __str__(self):
-        "__str__"
         return "Validation Error: %s" % self.description
 
 
@@ -75,7 +73,7 @@ def build_combinations_from_varlist(varlist):
 
 
 def expand_var_list(varlist, values):
-    """ exapand a state description
+    """Expand a state description.
 
     takes a {varname:value} dict and returns a list of {varname:value} but with
     stars and bangs replaced for all its possible values
@@ -199,7 +197,8 @@ class StateMachine(object):
                 spec = fsm_parser.parse(input_data)
             elif input_data.endswith(".py"):
                 result = {}
-                exec open(input_data) in result
+                with open(input_data) as f:
+                    exec(f.read(), result)
                 spec = result["state_machine"]
             else:
                 raise ValueError("Unknown input format")
@@ -212,11 +211,13 @@ class StateMachine(object):
         self.param_vars = {}
         self.build()
 
-    def validate(self):
+    def validate(self, verbose=False):
         """Raises an exception if the file had errors."""
         if self.errors:
-            raise ValidationFailed("There are %s validation errors" %
-                                   len(self.errors))
+            msg = "There are %s validation errors." % len(self.errors)
+            if verbose:
+                msg += 'Errors:\n%s' % '\n'.join(str(e) for e in self.errors)
+            raise ValidationFailed(msg)
         return True
 
     def get_variable_values(self, kind, name):
@@ -516,8 +517,8 @@ if __name__ == "__main__":
     s = StateMachine(sys.argv[1], sys.argv[2:])
     if s.errors:
         for e in s.errors:
-            print >> sys.stderr, e
-        print "There are %s errors" % (len(s.errors))
+            print e >> sys.stderr
+        print("There are %s errors" % (len(s.errors)))
         exit(1)
     else:
-        print "validated ok."
+        print("validated ok.")

--- a/magicicadaclient/syncdaemon/fsm/fsm_parser.py
+++ b/magicicadaclient/syncdaemon/fsm/fsm_parser.py
@@ -312,7 +312,7 @@ def main():
     (options, args) = parser.parse_args()
     if len(args) != 1:
         parser.print_help()
-        print "SPREADSHEET required"
+        print("SPREADSHEET required")
         return
 
     result = parse(args[0])

--- a/magicicadaclient/syncdaemon/hash_queue.py
+++ b/magicicadaclient/syncdaemon/hash_queue.py
@@ -30,7 +30,7 @@
 
 import logging
 import threading
-import Queue
+import Queue as queue
 import time
 
 from collections import OrderedDict
@@ -225,12 +225,12 @@ class HashQueue(object):
         return False
 
 
-class UniqueQueue(Queue.Queue):
+class UniqueQueue(queue.Queue):
     """Variant of Queue that only inserts unique items in the Queue."""
 
     def __init__(self, *args, **kwargs):
         """create the instance"""
-        Queue.Queue.__init__(self, *args, **kwargs)
+        queue.Queue.__init__(self, *args, **kwargs)
         self.logger = logging.getLogger(
             '.'.join((__name__, self.__class__.__name__)))
 

--- a/magicicadaclient/syncdaemon/interaction_interfaces.py
+++ b/magicicadaclient/syncdaemon/interaction_interfaces.py
@@ -35,6 +35,7 @@ Windows) and syncdaemon.
 Syncdaemon handles ONLY string volume ID's and ONLY string paths (always bytes
 encoded with utf-8). We assume the external interfaces will ALWAYS handle
 unicode, so ID's and paths will be encoded to bytes with utf-8 in this layer.
+
 """
 
 import collections
@@ -80,14 +81,15 @@ def get_share_dict(share):
     if 'subscribed' not in share_dict:
         share_dict['subscribed'] = share.subscribed
     for k, v in share_dict.items():
+        k = unicode(k)
         if v is None:
-            share_dict[unicode(k)] = ''
+            share_dict[k] = ''
         elif k == 'path':
-            share_dict[unicode(k)] = v.decode('utf-8')
+            share_dict[k] = v.decode('utf-8')
         elif k == 'accepted' or k == 'subscribed':
-            share_dict[unicode(k)] = bool_str(v)
+            share_dict[k] = bool_str(v)
         else:
-            share_dict[unicode(k)] = unicode(v)
+            share_dict[k] = unicode(v)
     return share_dict
 
 
@@ -95,16 +97,17 @@ def get_udf_dict(udf):
     """Get a dict with all the attributes of: udf."""
     udf_dict = udf.__dict__.copy()
     for k, v in udf_dict.items():
+        k = unicode(k)
         if v is None:
-            udf_dict[unicode(k)] = ''
+            udf_dict[k] = ''
         elif k == 'subscribed':
-            udf_dict[unicode(k)] = bool_str(v)
+            udf_dict[k] = bool_str(v)
         elif k == 'path':
-            udf_dict[unicode(k)] = v.decode('utf-8')
+            udf_dict[k] = v.decode('utf-8')
         elif k == 'suggested_path' and isinstance(v, str):
-            udf_dict[unicode(k)] = v.decode('utf-8')
+            udf_dict[k] = v.decode('utf-8')
         else:
-            udf_dict[unicode(k)] = unicode(v)
+            udf_dict[k] = unicode(v)
     return udf_dict
 
 
@@ -754,11 +757,7 @@ class SyncdaemonEventListener(SyncdaemonObject):
 
     @unicode_to_bytes
     def _get_path(self, share_id, node_id):
-        """Get the path from the given ids.
-
-        This is an unicode boundary, so return an unicode path.
-
-        """
+        """Get the path from the given ids."""
         try:
             relpath = self.fs_manager.get_by_node_id(share_id, node_id).path
         except KeyError:

--- a/magicicadaclient/syncdaemon/logger.py
+++ b/magicicadaclient/syncdaemon/logger.py
@@ -48,6 +48,7 @@ from magicicadaclient.platform import (
     setup_filesystem_logging,
 )
 
+
 DebugCapture = logger.DebugCapture
 NOTE = logger.NOTE
 TRACE = logger.TRACE

--- a/magicicadaclient/syncdaemon/sync.py
+++ b/magicicadaclient/syncdaemon/sync.py
@@ -1192,7 +1192,7 @@ class Sync(object):
                         continue
 
                 # if the delta is older than the node, skip!
-                if node.generation > dt.generation:
+                if node.generation and node.generation > dt.generation:
                     continue
 
                 # if the path changed, we have a move, notify it

--- a/magicicadaclient/syncdaemon/tests/fsm/test_fsm.py
+++ b/magicicadaclient/syncdaemon/tests/fsm/test_fsm.py
@@ -156,8 +156,9 @@ class TestParse(unittest.TestCase):
         """Test that na param columns are ignored."""
         f = fsm.StateMachine(p("test_param_na.ods"))
         f.validate()
-        self.assertEqual(f.events["EVENT_2"].transitions[0].parameters.keys(),
-                         [u"MV2"],)
+        self.assertEqual(
+            list(f.events["EVENT_2"].transitions[0].parameters.keys()),
+            [u"MV2"])
 
     def test_func_na(self):
         """Test that na param columns are ignored."""

--- a/magicicadaclient/syncdaemon/tests/test_config.py
+++ b/magicicadaclient/syncdaemon/tests/test_config.py
@@ -622,7 +622,8 @@ class SyncDaemonConfigParserTests(BaseTwistedTestCase):
         self.default_config = os.path.join(os.environ['ROOTDIR'], 'data',
                                            'syncdaemon.conf')
         self.cp = config.SyncDaemonConfigParser()
-        self.cp.readfp(file(self.default_config))
+        with open(self.default_config) as f:
+            self.cp.readfp(f)
 
     def test_log_level_old_config(self):
         """Test log_level upgrade hook."""

--- a/magicicadaclient/syncdaemon/tests/test_eq_inotify.py
+++ b/magicicadaclient/syncdaemon/tests/test_eq_inotify.py
@@ -710,9 +710,8 @@ class AncestorsUDFTestCase(BaseTwistedTestCase):
             if len(msg) > 0:
                 msg += '\n'
             exception = self.failureException(
-                '%snot equal:\na = %s\nb = %s\n'
-                % (msg, repr(first), repr(second)))
-            self._deferred.errback(msg)
+                '%snot equal:\na = %r\nb = %r\n' % (msg, first, second))
+            self._deferred.errback(exception)
             raise exception
         return first
     assertEqual = failUnlessEqual

--- a/magicicadaclient/syncdaemon/tests/test_eventqueue.py
+++ b/magicicadaclient/syncdaemon/tests/test_eventqueue.py
@@ -89,6 +89,7 @@ class SubscriptionTests(BaseEQTestCase):
 
     def test_subscription_simple(self):
         """Subscribe creating the listener map."""
+
         class Listener(object):
             """Listener."""
 
@@ -170,6 +171,7 @@ class SubscriptionTests(BaseEQTestCase):
 
     def test_unsubscription(self):
         """Test that unsubscription works."""
+
         class Listener1(object):
             """Listener 1."""
 

--- a/magicicadaclient/syncdaemon/tests/test_eventsnanny.py
+++ b/magicicadaclient/syncdaemon/tests/test_eventsnanny.py
@@ -153,7 +153,7 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
                         ("AQ_DOWNLOAD_FINISHED", "", "nodeid", "s_hash"),
             ])
-            self.assertFalse(self.tf in self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._blocked)
 
         d = defer.Deferred()
         d.addCallback(check)
@@ -171,7 +171,7 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("FS_FILE_OPEN", self.tf),
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
 
         d = defer.Deferred()
         d.addCallback(check)
@@ -184,7 +184,7 @@ class DownloadFinishedTests(BaseTwistedTestCase):
             self.assertEqual(self.listener.events(), [
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
 
         d = self.insert_in_hq(self.tf, "nodeid")
         d.addCallback(lambda _: self.eq.push("AQ_DOWNLOAD_COMMIT", share_id="",
@@ -204,13 +204,13 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("FS_FILE_OPEN", self.tf),
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
 
         def check2(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_CLOSE_WRITE", self.tf),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
 
         d = defer.Deferred()
         d.addCallback(check1)
@@ -231,15 +231,15 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("FS_FILE_OPEN", self.tf),
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
             self.assertEqual(self.nanny._opened[self.tf], 1)
 
         def check2(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_CLOSE_WRITE", self.tf),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
-            self.assertFalse(self.tf in self.nanny._opened)
+            self.assertIn(self.tf, self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._opened)
 
         d = defer.Deferred()
         d.addCallback(check1)
@@ -260,7 +260,7 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("FS_FILE_OPEN", self.tf),
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
             self.assertEqual(self.nanny._opened[self.tf], 1)
 
         def check2(_):
@@ -268,8 +268,8 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("FS_FILE_CLOSE_NOWRITE", self.tf),
                         ("AQ_DOWNLOAD_FINISHED", "", "nodeid", "s_hash"),
             ])
-            self.assertFalse(self.tf in self.nanny._blocked)
-            self.assertFalse(self.tf in self.nanny._opened)
+            self.assertNotIn(self.tf, self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._opened)
 
         d = defer.Deferred()
         d.addCallback(check1)
@@ -290,42 +290,42 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("FS_FILE_OPEN", self.tf),
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
             self.assertEqual(self.nanny._opened[self.tf], 1)
-            self.assertFalse(self.tf in self.nanny._hashing)
+            self.assertNotIn(self.tf, self.nanny._hashing)
 
         def check2(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_CLOSE_WRITE", self.tf),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
-            self.assertFalse(self.tf in self.nanny._opened)
-            self.assertTrue(self.tf in self.nanny._hashing)
+            self.assertIn(self.tf, self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._opened)
+            self.assertIn(self.tf, self.nanny._hashing)
 
         def check3(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_OPEN", self.tf),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
             self.assertEqual(self.nanny._opened[self.tf], 1)
-            self.assertTrue(self.tf in self.nanny._hashing)
+            self.assertIn(self.tf, self.nanny._hashing)
 
         def check4(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_CLOSE_NOWRITE", self.tf),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
-            self.assertFalse(self.tf in self.nanny._opened)
-            self.assertTrue(self.tf in self.nanny._hashing)
+            self.assertIn(self.tf, self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._opened)
+            self.assertIn(self.tf, self.nanny._hashing)
 
         def check5(_):
             self.assertEqual(self.listener.events(), [
                         ("HQ_HASH_NEW", self.tf, "crc", "hash", "size", "stt"),
                         ("AQ_DOWNLOAD_FINISHED", "", "nodeid", "s_hash"),
             ])
-            self.assertFalse(self.tf in self.nanny._blocked)
-            self.assertFalse(self.tf in self.nanny._opened)
-            self.assertFalse(self.tf in self.nanny._hashing)
+            self.assertNotIn(self.tf, self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._opened)
+            self.assertNotIn(self.tf, self.nanny._hashing)
 
         d = defer.Deferred()
         d.addCallback(check1)
@@ -357,14 +357,14 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
                         ("FS_FILE_OPEN", self.tf),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
             self.assertEqual(self.nanny._opened[self.tf], 2)
 
         def check2(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_CLOSE_NOWRITE", self.tf),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
             self.assertEqual(self.nanny._opened[self.tf], 1)
 
         def check3(_):
@@ -372,8 +372,8 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("FS_FILE_CLOSE_NOWRITE", self.tf),
                         ("AQ_DOWNLOAD_FINISHED", "", "nodeid", "s_hash"),
             ])
-            self.assertFalse(self.tf in self.nanny._blocked)
-            self.assertFalse(self.tf in self.nanny._opened)
+            self.assertNotIn(self.tf, self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._opened)
 
         d = defer.Deferred()
         d.addCallback(check1)
@@ -397,20 +397,20 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("FS_FILE_OPEN", self.tf),
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
 
         def check2(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_CLOSE_NOWRITE", "other"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
 
         def check3(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_CLOSE_NOWRITE", self.tf),
                         ("AQ_DOWNLOAD_FINISHED", "", "nodeid", "s_hash"),
             ])
-            self.assertFalse(self.tf in self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._blocked)
 
         d = defer.Deferred()
         d.addCallback(check1)
@@ -429,14 +429,14 @@ class DownloadFinishedTests(BaseTwistedTestCase):
             self.assertEqual(self.listener.events(), [
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
 
         def check2(_):
             self.assertEqual(self.listener.events(), [
                         ("HQ_HASH_NEW", self.tf, "crc", "hash", "siz", "stt"),
                         ("AQ_DOWNLOAD_FINISHED", "", "nodeid", "s_hash"),
             ])
-            self.assertFalse(self.tf in self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._blocked)
 
         d = self.insert_in_hq(self.tf, "nodeid")
         d.addCallback(lambda _: self.eq.push("AQ_DOWNLOAD_COMMIT", share_id="",
@@ -461,23 +461,23 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("FS_FILE_OPEN", self.tf),
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
-            self.assertFalse(self.tf in self.nanny._hashing)
+            self.assertIn(self.tf, self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._hashing)
 
         def check2(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_CLOSE_WRITE", self.tf),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
-            self.assertTrue(self.tf in self.nanny._hashing)
+            self.assertIn(self.tf, self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._hashing)
 
         def check3(_):
             self.assertEqual(self.listener.events(), [
                         ("HQ_HASH_NEW", self.tf, "crc", "hash", "siz", "stt"),
                         ("AQ_DOWNLOAD_FINISHED", "", "nodeid", "s_hash"),
             ])
-            self.assertFalse(self.tf in self.nanny._blocked)
-            self.assertFalse(self.tf in self.nanny._hashing)
+            self.assertNotIn(self.tf, self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._hashing)
 
         d = defer.Deferred()
         d.addCallback(check1)
@@ -504,15 +504,15 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("FS_FILE_OPEN", self.tf),
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
             self.assertEqual(self.nanny._opened[self.tf], 1)
 
         def check2(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_CREATE", self.tf),
             ])
-            self.assertFalse(self.tf in self.nanny._blocked)
-            self.assertFalse(self.tf in self.nanny._opened)
+            self.assertNotIn(self.tf, self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._opened)
 
         d = defer.Deferred()
         d.addCallback(check1)
@@ -547,15 +547,15 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("FS_FILE_OPEN", self.tf),
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
             self.assertEqual(self.nanny._opened[self.tf], 1)
 
         def check2(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_DELETE", self.tf),
             ])
-            self.assertFalse(self.tf in self.nanny._blocked)
-            self.assertFalse(self.tf in self.nanny._opened)
+            self.assertNotIn(self.tf, self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._opened)
 
         d = defer.Deferred()
         d.addCallback(check1)
@@ -596,21 +596,21 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("FS_FILE_OPEN", self.tf),
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
 
         def check2(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_MOVE", self.tf, tf2),
             ])
-            self.assertFalse(self.tf in self.nanny._blocked)
-            self.assertTrue(tf2 in self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._blocked)
+            self.assertIn(tf2, self.nanny._blocked)
 
         def check3(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_CLOSE_NOWRITE", tf2),
                         ("AQ_DOWNLOAD_FINISHED", "", "nodeid", "s_hash"),
             ])
-            self.assertFalse(tf2 in self.nanny._blocked)
+            self.assertNotIn(tf2, self.nanny._blocked)
 
         d = defer.Deferred()
         d.addCallback(check1)
@@ -658,34 +658,34 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("FS_FILE_OPEN", tf5),
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid5", "s_hash"),
             ])
-            self.assertTrue(tf1 in self.nanny._blocked)
-            self.assertTrue(tf2 in self.nanny._blocked)
-            self.assertTrue(tf3 in self.nanny._blocked)
-            self.assertTrue(tf4 in self.nanny._blocked)
-            self.assertTrue(tf5 in self.nanny._blocked)
+            self.assertIn(tf1, self.nanny._blocked)
+            self.assertIn(tf2, self.nanny._blocked)
+            self.assertIn(tf3, self.nanny._blocked)
+            self.assertIn(tf4, self.nanny._blocked)
+            self.assertIn(tf5, self.nanny._blocked)
 
         def check2(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_DIR_MOVE", dir_from, dir_to),
             ])
-            self.assertTrue(tf1 in self.nanny._blocked)
-            self.assertFalse(tf2 in self.nanny._blocked)
-            self.assertTrue(newtf2 in self.nanny._blocked)
-            self.assertTrue(tf3 in self.nanny._blocked)
-            self.assertTrue(tf4 in self.nanny._blocked)
-            self.assertTrue(tf5 in self.nanny._blocked)
+            self.assertIn(tf1, self.nanny._blocked)
+            self.assertNotIn(tf2, self.nanny._blocked)
+            self.assertIn(newtf2, self.nanny._blocked)
+            self.assertIn(tf3, self.nanny._blocked)
+            self.assertIn(tf4, self.nanny._blocked)
+            self.assertIn(tf5, self.nanny._blocked)
 
         def check3(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_CLOSE_NOWRITE", newtf2),
                         ("AQ_DOWNLOAD_FINISHED", "", "nodeid2", "s_hash"),
             ])
-            self.assertTrue(tf1 in self.nanny._blocked)
-            self.assertFalse(tf2 in self.nanny._blocked)
-            self.assertFalse(newtf2 in self.nanny._blocked)
-            self.assertTrue(tf3 in self.nanny._blocked)
-            self.assertTrue(tf4 in self.nanny._blocked)
-            self.assertTrue(tf5 in self.nanny._blocked)
+            self.assertIn(tf1, self.nanny._blocked)
+            self.assertNotIn(tf2, self.nanny._blocked)
+            self.assertNotIn(newtf2, self.nanny._blocked)
+            self.assertIn(tf3, self.nanny._blocked)
+            self.assertIn(tf4, self.nanny._blocked)
+            self.assertIn(tf5, self.nanny._blocked)
 
         d = defer.Deferred()
         d.addCallback(check1)
@@ -711,6 +711,14 @@ class DownloadFinishedTests(BaseTwistedTestCase):
         # create the file and generate the initial events
         self.fsm.create(tf1, "")
         self.fsm.set_node_id(tf1, "nodeid")
+
+        def push_events(event_name, **event_kwargs):
+
+            def f(*a, **kw):
+                self.eq.push(event_name, **event_kwargs)
+
+            return f
+
         self.eq.push("FS_FILE_OPEN", path=tf1)
         self.eq.push("AQ_DOWNLOAD_COMMIT",
                      share_id="", node_id="nodeid", server_hash="s_hash")
@@ -722,60 +730,54 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
                         ("FS_FILE_OPEN", tf1),
             ])
-            self.assertTrue(tf1 in self.nanny._blocked)
+            self.assertIn(tf1, self.nanny._blocked)
             self.assertEqual(self.nanny._opened[tf1], 2)
-
-        def check2(_):
-            self.assertEqual(self.listener.events(), [
-                        ("FS_FILE_CLOSE_NOWRITE", tf1),
-            ])
-            self.assertTrue(tf1 in self.nanny._blocked)
-            self.assertEqual(self.nanny._opened[tf1], 1)
-
-        def check3(_):
-            self.assertEqual(self.listener.events(), [
-                        ("FS_FILE_MOVE", tf1, tf2),
-            ])
-            self.assertFalse(tf1 in self.nanny._blocked)
-            self.assertTrue(tf2 in self.nanny._blocked)
-            self.assertEqual(self.nanny._opened[tf2], 1)
-
-        def check4(_):
-            self.assertEqual(self.listener.events(), [
-                        ("FS_FILE_OPEN", tf2),
-                        ("FS_DIR_MOVE", dir_from, dir_to),
-            ])
-            self.assertFalse(tf2 in self.nanny._blocked)
-            self.assertTrue(newtf2 in self.nanny._blocked)
-            self.assertEqual(self.nanny._opened[newtf2], 2)
-
-        def check5(_):
-            self.assertEqual(self.listener.events(), [
-                        ("FS_FILE_CLOSE_NOWRITE", newtf2),
-                        ("FS_FILE_CLOSE_NOWRITE", newtf2),
-                        ("AQ_DOWNLOAD_FINISHED", "", "nodeid", "s_hash"),
-            ])
-            self.assertFalse(newtf2 in self.nanny._blocked)
-            self.assertFalse(newtf2 in self.nanny._opened)
-        """Open, Open, Close, MoveFile, Open, MoveDir, Close, Close... test!"""
 
         d = defer.Deferred()
         d.addCallback(check1)
-        d.addCallback(lambda _: self.eq.push("FS_FILE_CLOSE_NOWRITE",
-                                             path=tf1))
+        d.addCallback(push_events("FS_FILE_CLOSE_NOWRITE", path=tf1))
+
+        def check2(_):
+            self.assertEqual(
+                self.listener.events(), [("FS_FILE_CLOSE_NOWRITE", tf1)])
+            self.assertIn(tf1, self.nanny._blocked)
+            self.assertEqual(self.nanny._opened[tf1], 1)
+
         d.addCallback(check2)
-        d.addCallback(lambda _: self.eq.push("FS_FILE_MOVE",
-                                             path_from=tf1, path_to=tf2))
+        d.addCallback(push_events("FS_FILE_MOVE", path_from=tf1, path_to=tf2))
+
+        def check3(_):
+            self.assertEqual(
+                self.listener.events(), [("FS_FILE_MOVE", tf1, tf2)])
+            self.assertNotIn(tf1, self.nanny._blocked)
+            self.assertIn(tf2, self.nanny._blocked)
+            self.assertEqual(self.nanny._opened[tf2], 1)
+
         d.addCallback(check3)
-        d.addCallback(lambda _: self.eq.push("FS_FILE_OPEN",
-                                             path=tf2))
-        d.addCallback(lambda _: self.eq.push("FS_DIR_MOVE", path_from=dir_from,
-                                             path_to=dir_to))
+        d.addCallback(push_events("FS_FILE_OPEN", path=tf2))
+        d.addCallback(
+            push_events("FS_DIR_MOVE", path_from=dir_from, path_to=dir_to))
+
+        def check4(_):
+            self.assertEqual(self.listener.events(), [
+                ("FS_FILE_OPEN", tf2), ("FS_DIR_MOVE", dir_from, dir_to)])
+            self.assertNotIn(tf2, self.nanny._blocked)
+            self.assertIn(newtf2, self.nanny._blocked)
+            self.assertEqual(self.nanny._opened[newtf2], 2)
+
         d.addCallback(check4)
-        d.addCallback(lambda _: self.eq.push("FS_FILE_CLOSE_NOWRITE",
-                                             path=newtf2))
-        d.addCallback(lambda _: self.eq.push("FS_FILE_CLOSE_NOWRITE",
-                                             path=newtf2))
+        d.addCallback(push_events("FS_FILE_CLOSE_NOWRITE", path=newtf2))
+        d.addCallback(push_events("FS_FILE_CLOSE_NOWRITE", path=newtf2))
+
+        def check5(_):
+            self.assertEqual(self.listener.events(), [
+                ("FS_FILE_CLOSE_NOWRITE", newtf2),
+                ("FS_FILE_CLOSE_NOWRITE", newtf2),
+                ("AQ_DOWNLOAD_FINISHED", "", "nodeid", "s_hash"),
+            ])
+            self.assertNotIn(newtf2, self.nanny._blocked)
+            self.assertNotIn(newtf2, self.nanny._opened)
+
         d.addCallback(check5)
         d.callback(None)
         return d
@@ -786,26 +788,26 @@ class DownloadFinishedTests(BaseTwistedTestCase):
             self.assertEqual(self.listener.events(), [
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
 
         def check2(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_OPEN", self.tf),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
 
         def check3(_):
             self.assertEqual(self.listener.events(), [
                         ("HQ_HASH_NEW", self.tf, "crc", "hash", "siz", "stt"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
 
         def check4(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_CLOSE_NOWRITE", self.tf),
                         ("AQ_DOWNLOAD_FINISHED", "", "nodeid", "s_hash"),
             ])
-            self.assertFalse(self.tf in self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._blocked)
 
         d = self.insert_in_hq(self.tf, "nodeid")
         d.addCallback(lambda _: self.eq.push("AQ_DOWNLOAD_COMMIT", share_id="",
@@ -835,20 +837,20 @@ class DownloadFinishedTests(BaseTwistedTestCase):
                         ("FS_FILE_OPEN", self.tf),
                         ("AQ_DOWNLOAD_COMMIT", "", "nodeid", "s_hash"),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
 
         def check2(_):
             self.assertEqual(self.listener.events(), [
                         ("FS_FILE_CLOSE_NOWRITE", self.tf),
             ])
-            self.assertTrue(self.tf in self.nanny._blocked)
+            self.assertIn(self.tf, self.nanny._blocked)
 
         def check3(_):
             self.assertEqual(self.listener.events(), [
                         ("HQ_HASH_NEW", self.tf, "crc", "hash", "siz", "stt"),
                         ("AQ_DOWNLOAD_FINISHED", "", "nodeid", "s_hash"),
             ])
-            self.assertFalse(self.tf in self.nanny._blocked)
+            self.assertNotIn(self.tf, self.nanny._blocked)
 
         d = defer.Deferred()
         d.addCallback(check1)

--- a/magicicadaclient/syncdaemon/tests/test_fileshelf.py
+++ b/magicicadaclient/syncdaemon/tests/test_fileshelf.py
@@ -29,8 +29,8 @@
 """Test file based persistent shelf."""
 
 import cPickle as pickle
-import os
 import hashlib
+import os
 import unittest
 
 from twisted.internet import defer

--- a/magicicadaclient/syncdaemon/tests/test_localrescan.py
+++ b/magicicadaclient/syncdaemon/tests/test_localrescan.py
@@ -1407,7 +1407,7 @@ class BadStateTests(TwistedBase):
     def _hash(self, path):
         """Hashes a file."""
         hasher = storage_hash.content_hash_factory()
-        with open_file(path) as fh:
+        with open_file(path, 'rb') as fh:
             while True:
                 cont = fh.read(65536)
                 if not cont:

--- a/magicicadaclient/syncdaemon/tests/test_offloadqueue.py
+++ b/magicicadaclient/syncdaemon/tests/test_offloadqueue.py
@@ -285,6 +285,7 @@ class OffloadQueueTestCase(TwistedTestCase):
 
     def _test_safe_push_write(self, count):
         """Fail when pushing an item will leave it all ok."""
+
         class CrashingFile(StringIO.StringIO):
             """File-like object that crashes in second write."""
             def __init__(self):

--- a/magicicadaclient/syncdaemon/tests/test_u1fsfsm.py
+++ b/magicicadaclient/syncdaemon/tests/test_u1fsfsm.py
@@ -35,15 +35,11 @@ import os
 from magicicadaclient.syncdaemon.fsm import fsm
 
 
-def p(name):
-    """make a full path from here."""
-    return os.path.join(os.path.dirname(fsm.__file__), name)
-
-
 class TestParse(unittest.TestCase):
     'Test fsm validation'
 
     def test_u1fsfsm(self):
         'test parsing a simple machine'
-        f = fsm.StateMachine(p("../u1fsfsm.py"))
+        path = os.path.join(os.path.dirname(fsm.__file__), "../u1fsfsm.py")
+        f = fsm.StateMachine(path)
         f.validate()

--- a/magicicadaclient/syncdaemon/tritcask.py
+++ b/magicicadaclient/syncdaemon/tritcask.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 Chicharreros (https://launchpad.net/~chicharreros)
+# Copyright 2022 Chicharreros (https://launchpad.net/~chicharreros)
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published

--- a/magicicadaclient/syncdaemon/vm_helper.py
+++ b/magicicadaclient/syncdaemon/vm_helper.py
@@ -101,7 +101,6 @@ def get_udf_suggested_path(path):
     assert isinstance(path, str)
 
     path = path.decode('utf8')
-
     user_home = expand_user('~').decode('utf-8')
     start_list = os.path.abspath(user_home).split(os.path.sep)
     path_list = os.path.abspath(path).split(os.path.sep)

--- a/magicicadaclient/testing/testcase.py
+++ b/magicicadaclient/testing/testcase.py
@@ -314,6 +314,7 @@ class BaseTwistedTestCase(TwistedTestCase):
         mmtree(path): support read-only shares
         makedirs(path): support read-only shares
     """
+
     MAX_FILENAME = 32  # some platforms limit lengths of filenames
 
     def mktemp(self, name='temp'):
@@ -332,9 +333,7 @@ class BaseTwistedTestCase(TwistedTestCase):
         # check if we already generated the root path
         if self.__root:
             return self.__root
-        base = os.path.join(self.__class__.__module__[:self.MAX_FILENAME],
-                            self.__class__.__name__[:self.MAX_FILENAME],
-                            self._testMethodName)
+        base = os.path.join(*self.id().split('.'))
         self.__root = os.path.join(root_tmp, base)
         self.addCleanup(self.rmtree, self.__root)
         return self.__root
@@ -379,8 +378,8 @@ class BaseTwistedTestCase(TwistedTestCase):
         try:
             shutil.rmtree(path)
         except Exception as e:
-            print 'ERROR!! could not recursively remove %r ' \
-                  '(error is %r).' % (path, e)
+            print('ERROR!! could not recursively remove %r (error is %r).' % (
+                path, e))
 
     def makedirs(self, path):
         """Custom makedirs that handle ro parent."""

--- a/magicicadaclient/utils/__init__.py
+++ b/magicicadaclient/utils/__init__.py
@@ -136,11 +136,10 @@ def get_cert_dir():
         if sys.platform == "win32":
             ssl_cert_location = get_config_files()[1]
         elif sys.platform == "darwin":
-                main_app_dir = "".join(__file__.partition(".app")[:-1])
-                main_app_resources_dir = os.path.join(main_app_dir,
-                                                      "Contents",
-                                                      "Resources")
-                ssl_cert_location = main_app_resources_dir
+            main_app_dir = "".join(__file__.partition(".app")[:-1])
+            main_app_resources_dir = os.path.join(
+                main_app_dir, "Contents", "Resources")
+            ssl_cert_location = main_app_resources_dir
     elif any(plat in sys.platform for plat in ("win32", "darwin")):
         pkg_dir = os.path.dirname(__file__)
         src_tree_path = os.path.dirname(os.path.dirname(pkg_dir))


### PR DESCRIPTION
Docstrings and style cleanup, preemptively improve some test names.
Usage of print as sort-of function.
Remove warnings silencing.
Ensure Twisted's trial `debug` mode works and is useful.
Abuse some list() calls on future generators to help the Python 3 migration.