### PR TITLE
Do not manually remove temp files

### DIFF
--- a/magicicadaclient/syncdaemon/action_queue.py
+++ b/magicicadaclient/syncdaemon/action_queue.py
@@ -57,7 +57,7 @@ from twisted.python.failure import Failure, DefaultException
 from zope.interface import implementer
 
 from magicicadaclient import clientdefs
-from magicicadaclient.platform import platform, remove_file
+from magicicadaclient.platform import platform
 from magicicadaclient.syncdaemon.interfaces import IActionQueue, IMarker
 from magicicadaclient.syncdaemon.logger import mklog, TRACE
 from magicicadaclient.syncdaemon import config, offload_queue
@@ -516,7 +516,6 @@ class ZipQueue(object):
             failed = True
             if tempfile is not None:
                 tempfile.close()
-                remove_file(tempfile.name)
             reactor.callFromThread(deferred.errback, e)
         finally:
             # avoid triggering the deferred if already failed!
@@ -2445,9 +2444,8 @@ class Upload(ActionQueueCommand):
     def finish(self):
         """Release the semaphore if already acquired."""
         if self.tempfile is not None:
-            # clean the temporary file
+            # clean the temporary file, it's deleted as soon as it is closed
             self.tempfile.close()
-            remove_file(self.tempfile.name)
 
         if self.tx_semaphore is not None:
             self.tx_semaphore = self.tx_semaphore.release()

--- a/magicicadaclient/syncdaemon/tests/test_action_queue.py
+++ b/magicicadaclient/syncdaemon/tests/test_action_queue.py
@@ -60,7 +60,9 @@ from zope.interface.verify import verifyObject, verifyClass
 from devtools import handlers
 from magicicadaclient import clientdefs
 from magicicadaclient.logger import NOTE, TRACE
-from magicicadaclient.platform import open_file, platform, path_exists
+from magicicadaclient.platform import (
+    open_file, platform, path_exists, remove_file,
+)
 from magicicadaclient.syncdaemon import (
     action_queue,
     config,
@@ -137,7 +139,14 @@ class FakeTempFile(object):
         self.closed = 0  # be able to count how may close calls we had
         self.name = os.path.join(tmpdir, 'remove-me.zip')
         open_file(self.name, 'w').close()
-        self.close = lambda: setattr(self, 'closed', self.closed + 1)
+
+    def close(self):
+        self.closed += 1
+        # Mimic the behaviour of NamedTemporaryFile
+        # https://docs.python.org/3/library/tempfile.html
+        # If delete is true (the default), the file is deleted as soon as it
+        # is closed.
+        remove_file(self.name)
 
 
 class FakedEventQueue(EventQueue):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 configglue==1.1.3
 dbus-python==1.2.8
 magicicadaprotocol==2.0
+protobuf<4
 pycairo==1.18.2
 PyGObject==3.28.2
 pyinotify==0.9.6


### PR DESCRIPTION
Following the NamedTemporaryFile documentation, both for Python 2 and Python 3,
these are deleted as soon as they are closed, so the code shouldn't remove them
explicitely.